### PR TITLE
Conditional istanbul instrumentation to reduce filesize

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,9 @@
+const plugins = [];
+if (process.env.NODE_ENV === 'test') {
+	plugins.push(['istanbul']);
+}
+
+module.exports = {
+  presets: ['react-app'],
+  plugins
+};

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -13,8 +13,10 @@
 const cucumber = require('cypress-cucumber-preprocessor').default;
 
 module.exports = (on, config) => {
+	require('@cypress/code-coverage/task')(on, config);
 	// `on` is used to hook into various events Cypress emits
 	// `config` is the resolved Cypress config
 	on('file:preprocessor', cucumber());
-	on('task', require('@cypress/code-coverage/task'));
+
+	return config;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,15 +1260,221 @@
 			}
 		},
 		"@cypress/code-coverage": {
-			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/@cypress/code-coverage/-/code-coverage-1.14.0.tgz",
-			"integrity": "sha512-uzfbqPgNnLlzRLDX5lrW54gdacfjTcgkEY03JCltEhRwptQm5dtAZtHgNs0zVCBk/t02C/mlTq11QAJMUINzNA==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@cypress/code-coverage/-/code-coverage-3.8.1.tgz",
+			"integrity": "sha512-XkecqM/4xHZdAPUMOxOUi5yf2TDWUycqIi6Z6zdGiO9j04CxkRoVTOJYsE14i7uG7orudYSLcLFJEeJv237qXQ==",
 			"dev": true,
 			"requires": {
-				"@cypress/browserify-preprocessor": "2.1.4",
-				"bin-up": "1.3.2",
+				"@cypress/browserify-preprocessor": "3.0.0",
 				"debug": "4.1.1",
-				"execa": "4.0.0"
+				"execa": "4.0.2",
+				"globby": "11.0.0",
+				"istanbul-lib-coverage": "3.0.0",
+				"js-yaml": "3.14.0",
+				"nyc": "15.1.0"
+			},
+			"dependencies": {
+				"@babel/core": {
+					"version": "7.4.5",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
+					"integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.4.4",
+						"@babel/helpers": "^7.4.4",
+						"@babel/parser": "^7.4.5",
+						"@babel/template": "^7.4.4",
+						"@babel/traverse": "^7.4.5",
+						"@babel/types": "^7.4.4",
+						"convert-source-map": "^1.1.0",
+						"debug": "^4.1.0",
+						"json5": "^2.1.0",
+						"lodash": "^4.17.11",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@cypress/browserify-preprocessor": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@cypress/browserify-preprocessor/-/browserify-preprocessor-3.0.0.tgz",
+					"integrity": "sha512-8CXLCKlXVUnad5TjwVswq4nwwWVyt5Z+HMgrFaD2yF7A62AA6OYDrShTQnG6M6+hr1cq1X4zYbo7VT4oxex5hA==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "7.4.5",
+						"@babel/plugin-proposal-class-properties": "7.3.0",
+						"@babel/plugin-proposal-object-rest-spread": "7.3.2",
+						"@babel/plugin-transform-runtime": "7.2.0",
+						"@babel/preset-env": "7.4.5",
+						"@babel/preset-react": "7.0.0",
+						"@babel/runtime": "7.3.1",
+						"babel-plugin-add-module-exports": "1.0.2",
+						"babelify": "10.0.0",
+						"bluebird": "3.5.3",
+						"browserify": "16.2.3",
+						"coffeeify": "3.0.1",
+						"coffeescript": "1.12.7",
+						"debug": "4.1.1",
+						"fs-extra": "9.0.0",
+						"lodash.clonedeep": "4.5.0",
+						"through2": "^2.0.0",
+						"watchify": "3.11.1"
+					}
+				},
+				"@nodelib/fs.stat": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"dir-glob": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+					"dev": true,
+					"requires": {
+						"path-type": "^4.0.0"
+					}
+				},
+				"fast-glob": {
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+					"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.0",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.2",
+						"picomatch": "^2.2.1"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"fs-extra": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+					"integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+					"dev": true,
+					"requires": {
+						"at-least-node": "^1.0.0",
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^1.0.0"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+					"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globby": {
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
+					"integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"jsonfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6",
+						"universalify": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"universalify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"dev": true
+				}
 			}
 		},
 		"@cypress/listr-verbose-renderer": {
@@ -1813,10 +2019,38 @@
 				"glob-to-regexp": "^0.3.0"
 			}
 		},
+		"@nodelib/fs.scandir": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "2.0.3",
+				"run-parallel": "^1.1.9"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+					"dev": true
+				}
+			}
+		},
 		"@nodelib/fs.stat": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.3",
+				"fastq": "^1.6.0"
+			}
 		},
 		"@npmcli/move-file": {
 			"version": "1.0.1",
@@ -2189,6 +2423,7 @@
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
 			"integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+			"dev": true,
 			"requires": {
 				"@types/connect": "*",
 				"@types/node": "*"
@@ -2204,6 +2439,7 @@
 			"version": "3.4.33",
 			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
 			"integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -2218,6 +2454,7 @@
 			"version": "4.17.6",
 			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
 			"integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+			"dev": true,
 			"requires": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "*",
@@ -2229,6 +2466,7 @@
 			"version": "4.17.7",
 			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
 			"integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*",
 				"@types/qs": "*",
@@ -2278,7 +2516,8 @@
 		"@types/mime": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
-			"integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q=="
+			"integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==",
+			"dev": true
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -2289,7 +2528,8 @@
 		"@types/node": {
 			"version": "14.0.13",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-			"integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
+			"integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
+			"dev": true
 		},
 		"@types/parse-json": {
 			"version": "4.0.0",
@@ -2312,12 +2552,14 @@
 		"@types/qs": {
 			"version": "6.9.3",
 			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
-			"integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA=="
+			"integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA==",
+			"dev": true
 		},
 		"@types/range-parser": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+			"dev": true
 		},
 		"@types/react": {
 			"version": "16.9.38",
@@ -2342,6 +2584,7 @@
 			"version": "1.13.4",
 			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
 			"integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
+			"dev": true,
 			"requires": {
 				"@types/express-serve-static-core": "*",
 				"@types/mime": "*"
@@ -3984,34 +4227,6 @@
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
-		},
-		"bin-up": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/bin-up/-/bin-up-1.3.2.tgz",
-			"integrity": "sha512-ePRL4VTK6jE/rXyoTH/YjzLRqp397y/dUSRXrPe8OcVP4min4bLJxNhmTdZfEF4zQYn4yYaI6WGy8M7F1mY1Aw==",
-			"dev": true,
-			"requires": {
-				"execa": "2.0.5"
-			},
-			"dependencies": {
-				"execa": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-2.0.5.tgz",
-					"integrity": "sha512-SwmwZZyJjflcqLSgllk4EQlMLst2p9muyzwNugKGFlpAz6rZ7M+s2nBR97GAq4Vzjwx2y9rcMcmqzojwN+xwNA==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.5",
-						"get-stream": "^5.0.0",
-						"is-stream": "^2.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^3.0.0",
-						"onetime": "^5.1.0",
-						"p-finally": "^2.0.0",
-						"signal-exit": "^3.0.2",
-						"strip-final-newline": "^2.0.0"
-					}
-				}
-			}
 		},
 		"binary-extensions": {
 			"version": "1.13.1",
@@ -7472,9 +7687,9 @@
 			"dev": true
 		},
 		"execa": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.0.tgz",
-			"integrity": "sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
+			"integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.0",
@@ -7497,15 +7712,6 @@
 						"path-key": "^3.1.0",
 						"shebang-command": "^2.0.0",
 						"which": "^2.0.1"
-					}
-				},
-				"npm-run-path": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.0.0"
 					}
 				},
 				"path-key": {
@@ -7881,6 +8087,15 @@
 			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
 			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
 			"dev": true
+		},
+		"fastq": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+			"integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+			"dev": true,
+			"requires": {
+				"reusify": "^1.0.4"
+			}
 		},
 		"faye-websocket": {
 			"version": "0.10.0",
@@ -8314,9 +8529,9 @@
 			}
 		},
 		"fromentries": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
-			"integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.1.tgz",
+			"integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw==",
 			"dev": true
 		},
 		"fs-extra": {
@@ -12322,9 +12537,9 @@
 			}
 		},
 		"npm-run-path": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-			"integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
 			"dev": true,
 			"requires": {
 				"path-key": "^3.0.0"
@@ -12613,9 +12828,9 @@
 					}
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -12644,9 +12859,9 @@
 					}
 				},
 				"yargs": {
-					"version": "15.3.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-					"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
 					"dev": true,
 					"requires": {
 						"cliui": "^6.0.0",
@@ -12659,7 +12874,7 @@
 						"string-width": "^4.2.0",
 						"which-module": "^2.0.0",
 						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.1"
+						"yargs-parser": "^18.1.2"
 					}
 				},
 				"yargs-parser": {
@@ -15599,6 +15814,12 @@
 			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
 			"dev": true
 		},
+		"reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
+		},
 		"rework": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
@@ -15664,6 +15885,12 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
 			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+		},
+		"run-parallel": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+			"dev": true
 		},
 		"run-queue": {
 			"version": "1.0.3",
@@ -17608,7 +17835,8 @@
 		"ts-pnp": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
-			"integrity": "sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ=="
+			"integrity": "sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ==",
+			"dev": true
 		},
 		"tslib": {
 			"version": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -42,15 +42,14 @@
 	"scripts": {
 		"start": "node scripts/start.js",
 		"build": "node scripts/build.js",
-		"test": "npm run unit-tests && npm run cy:ci",
-		"posttest": "npm run report:combined",
+		"test": "NODE_ENV=test npm run unit-tests && NODE_ENV=test npm run cy:ci",
 		"test:it": "cypress open",
 		"cy:ci": "start-server-and-test start http://localhost:3000 integration-tests",
 		"unit-tests": "jest",
 		"integration-tests": "cypress run",
-		"prereport:combined": "cp coverage/cypress/coverage-final.json coverage/from-cypress.json && cp coverage/jest/coverage-final.json coverage/from-jest.json",
-		"report:combined": "nyc merge coverage && mv coverage.json .nyc_output/out.json",
-		"postreport:combined": "nyc report --reporter lcov --report-dir coverage",
+		"prereport:combined": "cp coverage/cypress/index.html coverage/from-cypress.html && cp coverage/jest/lcov-report/index.html coverage/from-jest.html",
+		"report:combined": "nyc merge coverage && mv coverage.html .nyc_output/out.html",
+		"postreport:combined": "nyc report --reporter html --report-dir coverage",
 		"format": "prettier --write \"**/*.+(js|jsx|json|css|md)\"",
 		"lint": "eslint ./src",
 		"lint:fix": "eslint --fix ./src"
@@ -130,27 +129,18 @@
 			"jest-watch-typeahead/testname"
 		]
 	},
-	"babel": {
-		"presets": [
-			"react-app"
-		],
-		"plugins": [
-			"istanbul"
-		]
-	},
 	"cypress-cucumber-preprocessor": {
 		"nonGlobalStepDefinitions": true
 	},
 	"nyc": {
 		"report-dir": "coverage/cypress",
 		"reporter": [
-			"text",
-			"json"
+			"html"
 		]
 	},
 	"devDependencies": {
 		"@babel/core": "7.9.0",
-		"@cypress/code-coverage": "^1.11.0",
+		"@cypress/code-coverage": "^3.8.1",
 		"@svgr/webpack": "4.3.3",
 		"@testing-library/jest-dom": "^4.2.4",
 		"@testing-library/react": "^9.5.0",
@@ -167,15 +157,15 @@
 		"case-sensitive-paths-webpack-plugin": "2.3.0",
 		"cypress": "^5.0.0",
 		"cypress-cucumber-preprocessor": "^2.5.0",
+		"eslint": "^6.6.0",
 		"eslint-config-airbnb": "^18.1.0",
 		"eslint-config-prettier": "^6.11.0",
-		"eslint-plugin-prettier": "^3.1.3",
-		"eslint": "^6.6.0",
 		"eslint-config-react-app": "^5.2.1",
 		"eslint-loader": "3.0.3",
 		"eslint-plugin-flowtype": "4.6.0",
 		"eslint-plugin-import": "2.20.1",
 		"eslint-plugin-jsx-a11y": "6.2.3",
+		"eslint-plugin-prettier": "^3.1.3",
 		"eslint-plugin-react": "7.19.0",
 		"eslint-plugin-react-hooks": "^1.6.1",
 		"file-loader": "4.3.0",
@@ -189,7 +179,7 @@
 		"mini-css-extract-plugin": "0.9.0",
 		"nock": "^11.7.2",
 		"node-sass": "^4.14.1",
-		"nyc": "^15.0.0",
+		"nyc": "^15.1.0",
 		"optimize-css-assets-webpack-plugin": "5.0.3",
 		"pnp-webpack-plugin": "1.6.4",
 		"postcss-flexbugs-fixes": "4.1.0",


### PR DESCRIPTION
Prevents local filepaths from showing up in package build, thereby reducing filesize.  Will need to be retrofitted to all our app module packages.

While trying to figure out the thing causing the `Cannot read property 'loc' of undefined` message that has been coming up intermittently, I discovered that the cypress code-coverage plugin needed to be updated.  Updated to new version and changed its configuration to that recommended in the docs.  

That created a new error which was resolved by limiting nyc output to `html` as opposed to lcov or json.