### PR TITLE
(#20) update editorconfig to handle yml files (spaces vs tabs)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
 max_line_length = off
+
+[*.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Closes #20 .

Yaml files don't play nicely with tabs.  Updated the .editorconfig file to use spaces instead of tabs for .yml files