### PR TITLE
(#29) Use Actions for Netstorage

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -131,91 +131,23 @@ jobs:
           pushd build-artifact
           zip -r ../${BUILD_NAME}.zip *
           popd
-      ## Hack for forcing python3 because using the python shell
-      ## by default uses 2.7
-      - name: Force using python3 for shell
-        shell: bash
-        run: |
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-      ## Install the Akamai netstorage module
-      - name: install python modules
-        shell: bash
-        run: |
-          ## Update Setup Tools so that Edgegrid can install
-          python -m pip install --upgrade pip setuptools wheel
-          pip install -Iv netstorageapi==1.2.12
-          pip install requests edgegrid-python
-      ## Actually do the upload
       - name: Upload artifact to netstorage
-        shell: python
-        env:
-          NS_HOSTNAME: ${{ secrets.ns_hostname }}
-          NS_KEYNAME: ${{ secrets.ns_keyname }}
-          NS_KEY: ${{ secrets.ns_key }}
-          NS_CPCODE: ${{ secrets.ns_cpcode }}
-          PROP_CPCODE: ${{ secrets.prop_cpcode }}
-          EG_HOSTNAME: ${{ secrets.eg_hostname }}
-          EG_CLIENT_TOKEN: ${{ secrets.eg_client_token }}
-          EG_CLIENT_SECRET: ${{ secrets.eg_client_secret }}
-          EG_ACCESS_TOKEN: ${{ secrets.eg_access_token }}
-          ARTIFACT_FILENAME: ${{ format('{0}.zip', steps.set_vars.outputs.build_name) }}
-        run: |
-          import os
-          import requests
-          from akamai.netstorage import Netstorage, NetstorageError
-          from akamai.edgegrid import EdgeGridAuth
-          from urllib.parse import urljoin
-
-          NS_HOSTNAME = os.environ.get('NS_HOSTNAME')
-          NS_KEYNAME = os.environ.get('NS_KEYNAME')
-          NS_KEY = os.environ.get('NS_KEY')
-          NS_CPCODE = os.environ.get('NS_CPCODE')
-          REPO_NAME = os.environ.get('REPO_NAME')
-          BUILD_NAME = os.environ.get('BUILD_NAME')
-          PROP_CPCODE = os.environ.get('PROP_CPCODE')
-          EG_HOSTNAME = os.environ.get('EG_HOSTNAME')
-          EG_CLIENT_TOKEN = os.environ.get('EG_CLIENT_TOKEN')
-          EG_CLIENT_SECRET = os.environ.get('EG_CLIENT_SECRET')
-          EG_ACCESS_TOKEN = os.environ.get('EG_ACCESS_TOKEN')
-
-          artifact_filename = '{0}.zip'.format(BUILD_NAME)
-          local_source = os.path.join(os.getcwd(), artifact_filename)
-          netstorage_destination = '/{0}/{1}/{2}'.format(NS_CPCODE, REPO_NAME, artifact_filename)
-
-          ## Upload to Netstorage
-          ns = Netstorage(NS_HOSTNAME, NS_KEYNAME, NS_KEY, True)
-          ok, response = ns.upload(local_source, netstorage_destination, True)
-
-          if not ok:
-            # Error occurred
-            print(response)
-            exit(1)
-
-          ## Clear cache
-          session = requests.Session()
-          session.auth = EdgeGridAuth(
-            client_token=EG_CLIENT_TOKEN,
-            client_secret=EG_CLIENT_SECRET,
-            access_token=EG_ACCESS_TOKEN
-          )
-
-          ## Purge the cache
-          purge_result = session.post(
-            urljoin(EG_HOSTNAME, '/ccu/v3/delete/cpcode/production'),
-            json={
-              "objects": [NS_CPCODE, PROP_CPCODE]
-            }
-          )
-
-          ## Handle error from purge
-          if (purge_result.status_code != 201) :
-            print("Purge failed")
-            print(purge_result.reason)
-            print(purge_result.content)
-            exit(2)
-
-          ## Sucessfully Completed.
-          print("Uploaded {0} successfully".format(artifact_filename))
-          exit(0)
-
-## TODO: Post notice PR is ready for testing
+        uses: nciocpl/netstorage-upload-action@v1.0.0
+        with:
+          hostname: ${{ secrets.ns_hostname }}
+          cp-code: ${{ secrets.ns_cpcode }}
+          key-name: ${{ secrets.ns_keyname }}
+          key: ${{ secrets.ns_key }}
+          index-zip: true
+          local-path: ${{ format('{0}.zip', env.BUILD_NAME) }}
+          ## Note this action automatically prepends the cpcode to the path.
+          destination-path: ${{ format('/{0}/{1}.zip', env.REPO_NAME, env.BUILD_NAME) }}
+      - name: Clear Site Cache
+        uses: nciocpl/akamai-purge-action@v1.0.2
+        with:
+          hostname: ${{ secrets.eg_hostname }}
+          client-token: ${{ secrets.eg_client_token }}
+          client-secret: ${{ secrets.eg_client_secret }}
+          access-token: ${{ secrets.eg_access_token }}
+          type: 'cpcodes'
+          ref: ${{ format('{0},{1}', secrets.ns_cpcode, secrets.prop_cpcode) }}

--- a/.pa11yci
+++ b/.pa11yci
@@ -4,5 +4,12 @@
     "http://localhost:3000/item/6789",
     "http://localhost:3000/item/99999",
     "http://localhost:3000/chicken"
-  ]
+  ],
+	"chromeLaunchConfig": {
+		"args": [
+			"--no-sandbox",
+			"--disable-setuid-sandbox",
+			"--disable-dev-shm-usage"
+		]
+	}
 }


### PR DESCRIPTION
This PR updates our workflow to use Github Actions to upload to netstorage, as well as clearing the akamai cache for said netstorage. This replaces all the python stuff in the original workflow. 

I also added the fix for Pa11y and crashing during workflows.

Closes #29 
Closes #30