### PR TITLE
(#38) Fix overall code coverage

### DIFF
--- a/merged.nyc.config.js
+++ b/merged.nyc.config.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/******
+ * This file is the configuration for the final merged report.
+ */
+module.exports = {
+	'report-dir': 'coverage/merged',
+	'temp-dir': 'coverage/merged',
+	reporter: ['html', 'json', 'lcov', 'text'],
+	'check-coverage': true,
+	branches: 80,
+	lines: 80,
+	functions: 80,
+	statements: 80,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,17 +1260,19 @@
 			}
 		},
 		"@cypress/code-coverage": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@cypress/code-coverage/-/code-coverage-3.8.1.tgz",
-			"integrity": "sha512-XkecqM/4xHZdAPUMOxOUi5yf2TDWUycqIi6Z6zdGiO9j04CxkRoVTOJYsE14i7uG7orudYSLcLFJEeJv237qXQ==",
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/@cypress/code-coverage/-/code-coverage-3.9.10.tgz",
+			"integrity": "sha512-aJokd9B1/cI8uQAH4tPw9yuZg7a/bdl1xO4xSeO4ly5Tlj8L3/eJ2vvJf5RcfHAZQE1OMOYY7ZtPuBBE8eItYw==",
 			"dev": true,
 			"requires": {
-				"@cypress/browserify-preprocessor": "3.0.0",
-				"debug": "4.1.1",
-				"execa": "4.0.2",
-				"globby": "11.0.0",
+				"@cypress/browserify-preprocessor": "3.0.1",
+				"chalk": "4.1.2",
+				"dayjs": "1.10.6",
+				"debug": "4.3.2",
+				"execa": "4.1.0",
+				"globby": "11.0.4",
 				"istanbul-lib-coverage": "3.0.0",
-				"js-yaml": "3.14.0",
+				"js-yaml": "3.14.1",
 				"nyc": "15.1.0"
 			},
 			"dependencies": {
@@ -1297,9 +1299,9 @@
 					}
 				},
 				"@cypress/browserify-preprocessor": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@cypress/browserify-preprocessor/-/browserify-preprocessor-3.0.0.tgz",
-					"integrity": "sha512-8CXLCKlXVUnad5TjwVswq4nwwWVyt5Z+HMgrFaD2yF7A62AA6OYDrShTQnG6M6+hr1cq1X4zYbo7VT4oxex5hA==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/@cypress/browserify-preprocessor/-/browserify-preprocessor-3.0.1.tgz",
+					"integrity": "sha512-sErmFSEr5287bLMRl0POGnyFtJCs/lSk5yxrUIJUIHZ8eDvtTEr0V93xRgLjJVG54gJU4MbpHy1mRPA9VZbtQA==",
 					"dev": true,
 					"requires": {
 						"@babel/core": "7.4.5",
@@ -1320,13 +1322,33 @@
 						"lodash.clonedeep": "4.5.0",
 						"through2": "^2.0.0",
 						"watchify": "3.11.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.1.1",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+							"dev": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						}
 					}
 				},
 				"@nodelib/fs.stat": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
 					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
 				},
 				"array-union": {
 					"version": "2.1.0",
@@ -1343,6 +1365,40 @@
 						"fill-range": "^7.0.1"
 					}
 				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
 				"dir-glob": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1353,17 +1409,16 @@
 					}
 				},
 				"fast-glob": {
-					"version": "3.2.4",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-					"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+					"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
 					"dev": true,
 					"requires": {
 						"@nodelib/fs.stat": "^2.0.2",
 						"@nodelib/fs.walk": "^1.2.3",
-						"glob-parent": "^5.1.0",
+						"glob-parent": "^5.1.2",
 						"merge2": "^1.3.0",
-						"micromatch": "^4.0.2",
-						"picomatch": "^2.2.1"
+						"micromatch": "^4.0.4"
 					}
 				},
 				"fill-range": {
@@ -1388,18 +1443,18 @@
 					}
 				},
 				"glob-parent": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-					"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
 					}
 				},
 				"globby": {
-					"version": "11.0.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-					"integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+					"version": "11.0.4",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
 					"dev": true,
 					"requires": {
 						"array-union": "^2.1.0",
@@ -1410,10 +1465,10 @@
 						"slash": "^3.0.0"
 					}
 				},
-				"ignore": {
-					"version": "5.1.8",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
 				"is-number": {
@@ -1422,30 +1477,54 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
 				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
 				"jsonfile": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.6",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
+					},
+					"dependencies": {
+						"universalify": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+							"dev": true
+						}
 					}
 				},
 				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
 					"dev": true,
 					"requires": {
 						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
+						"picomatch": "^2.2.3"
 					}
 				},
 				"path-type": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"picomatch": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
 					"dev": true
 				},
 				"semver": {
@@ -1459,6 +1538,15 @@
 					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				},
 				"to-regex-range": {
 					"version": "5.0.1",
@@ -7076,6 +7164,12 @@
 			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
 			"dev": true
 		},
+		"dayjs": {
+			"version": "1.10.6",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
+			"integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==",
+			"dev": true
+		},
 		"debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -9234,9 +9328,9 @@
 			"dev": true
 		},
 		"execa": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
-			"integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -42,17 +42,18 @@
 	"scripts": {
 		"start": "node scripts/start.js",
 		"build": "node scripts/build.js",
-		"test": "NODE_ENV=test npm run lint && NODE_ENV=test npm run pa11y-tests && NODE_ENV=test npm run unit-tests && NODE_ENV=test npm run cy:ci",
+		"test": "NODE_ENV=test npm run lint && NODE_ENV=test npm run pa11y-tests && NODE_ENV=test npm run unit-tests && NODE_ENV=test npm run cy:ci && npm run merge-coverage",
 		"test:it": "cypress open",
 		"test:pa11y": "./node_modules/.bin/pa11y-ci",
 		"pa11y-tests": "start-server-and-test start http://localhost:3000 pa11y",
 		"pa11y": "pa11y-ci",
-		"cy:ci": "start-server-and-test start http://localhost:3000 integration-tests",
+		"cy:ci": "start-server-and-test start http://localhost:3000 integration-tests && nyc report -t coverage/cypress --reporter text --report-dir coverage/merged",
 		"unit-tests": "jest",
 		"integration-tests": "cypress run",
-		"prereport:combined": "cp coverage/cypress/index.html coverage/from-cypress.html && cp coverage/jest/lcov-report/index.html coverage/from-jest.html",
-		"report:combined": "nyc merge coverage && mv coverage.html .nyc_output/out.html",
-		"postreport:combined": "nyc report --reporter html --report-dir coverage",
+		"merge-coverage": "npm run mc:pre && npm run mc:merge && npm run mc:report",
+		"mc:pre": "node scripts/pre-merge-coverage",
+		"mc:merge": "nyc merge coverage/tmp coverage/merged/coverage-final.json",
+		"mc:report": "nyc report --nycrc-path=merged.nyc.config.js",
 		"format": "prettier --write \"**/*.+(js|jsx|json|css|md)\"",
 		"lint": "eslint src --ext .js,.jsx",
 		"lint:fix": "eslint src --ext .js,.jsx --fix"
@@ -138,12 +139,19 @@
 	"nyc": {
 		"report-dir": "coverage/cypress",
 		"reporter": [
-			"html"
+			"html",
+			"json",
+			"lcov"
+		],
+		"exclude": [
+			"cypress/**/*.js",
+			"jest-test-setup.js",
+			"src/setupTests.js"
 		]
 	},
 	"devDependencies": {
 		"@babel/core": "7.9.0",
-		"@cypress/code-coverage": "^3.8.1",
+		"@cypress/code-coverage": "^3.9.10",
 		"@svgr/webpack": "4.3.3",
 		"@testing-library/jest-dom": "^5.12.0",
 		"@testing-library/react": "^11.2.6",

--- a/scripts/pre-merge-coverage.js
+++ b/scripts/pre-merge-coverage.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs-extra');
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', (err) => {
+	throw err;
+});
+
+// Make sure any symlinks in the project folder are resolved:
+// https://github.com/facebook/create-react-app/issues/637
+const appDirectory = fs.realpathSync(process.cwd());
+const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
+
+const main = async () => {
+	try {
+		// Create, or empty, a tmp folder for the two coverage files.
+		await fs.emptyDir(resolveApp('coverage/tmp'));
+		// Copy the Jest coverage file
+		await fs.copy(
+			resolveApp('coverage/jest/coverage-final.json'),
+			resolveApp('coverage/tmp/jest-final.json')
+		);
+		// Copy the Cypress coverage
+		await fs.copy(
+			resolveApp('coverage/cypress/coverage-final.json'),
+			resolveApp('coverage/tmp/cypress-final.json')
+		);
+	} catch (err) {
+		console.error(err);
+		process.exit(1);
+	}
+};
+
+main();


### PR DESCRIPTION
- Added pre-merge script to setup comined coverage directories and copy coverage files from cypress and jest.
- Added merged coverage specific config, as the nyc section in package.json is used by cypress.
- Added text reporting after ALL integration tests finish. When text reporting is enabled Cypress reports after each feature.
- Added reporting for full merged coverage at the end with coverage checking set to 80%.
- Bumped @cypress/code-coverage to resolve issue with lcov generation failing.
  
NOTE: This requires remove of the <repo>/.nyc_output and <repo>/coverage directories.

Closes #38 