### PR TITLE
(#76) Change Node version in .nvmrc and workflow.yml

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,12 +59,12 @@ jobs:
             })
       ## This clones and checks out.
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ## Setup node and npm caching.
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version-file: '.nvmrc'
           cache: 'npm'
           registry-url: https://npm.pkg.github.com
           scope: '@nciocpl'

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-16
+lts/gallium


### PR DESCRIPTION
Closes #76

* Updated node version naming in `.nvmrc` and `workflow.yml` from `16` to `lts/gallium`