### PR TITLE
(#80) Limit when the workflow is called.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,18 @@
 name: Workflow
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - master
+      - main
+      - develop
+      - 'hotfix/**'
+      - 'release/**'
+      - 'feature/**'
+      - 'prototype/**'
+    tags:
+      - '*'
+  pull_request:
+  workflow_call:
 jobs:
   build:
     name: Build, Test and Upload Artifacts


### PR DESCRIPTION
For pull requests against ticket branches we do 2 builds. This limits limits the builds for ticket branches to be only for pull requests. This does have to be updated in each of the repos.

>**_NOTE:_** This has to be updated in each of the repos that use this workflow. However, this does not need to be workflow/v3 as the steps are not changing.

Closes #80