### PR TITLE
(#86) Change GH actions runner for pa11y tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     name: Build, Test and Upload Artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       ## Setup variables for build info
       - name: Set Variables


### PR DESCRIPTION
Closes #86 .

- update ubuntu version to `ubuntu-20.04` for pa11y tests to run