### PR TITLE
(#90) Update Code Coverage Scripts and Config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,6 @@
 const plugins = [];
-if (process.env.NODE_ENV === 'test') {
-	plugins.push(['istanbul']);
-}
 
 module.exports = {
-  presets: ['react-app'],
-  plugins
+	presets: ['react-app'],
+	plugins,
 };

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const isWsl = require('is-wsl');
 const path = require('path');
 const webpack = require('webpack');
 const resolve = require('resolve');
@@ -238,6 +239,11 @@ module.exports = function (webpackEnv) {
 						},
 					},
 					sourceMap: shouldUseSourceMap,
+					// Use multi-process parallel running to improve the build speed
+					// Default number of concurrent runs: os.cpus().length - 1
+					// Disabled on WSL (Windows Subsystem for Linux) due to an issue with Terser
+					// https://github.com/webpack-contrib/terser-webpack-plugin/issues/21
+					parallel: !isWsl,
 				}),
 				// This is only used in production mode
 				new OptimizeCSSAssetsPlugin({
@@ -371,20 +377,35 @@ module.exports = function (webpackEnv) {
 								customize: require.resolve(
 									'babel-preset-react-app/webpack-overrides'
 								),
-
-								plugins: [
-									[
-										require.resolve('babel-plugin-named-asset-import'),
-										{
-											loaderMap: {
-												svg: {
-													ReactComponent:
-														'@svgr/webpack?-svgo,+titleProp,+ref![path]',
+								// If this is development, then additionally add in the istanbul plugin
+								plugins: isEnvProduction
+									? [
+											[
+												require.resolve('babel-plugin-named-asset-import'),
+												{
+													loaderMap: {
+														svg: {
+															ReactComponent:
+																'@svgr/webpack?-svgo,+titleProp,+ref![path]',
+														},
+													},
 												},
-											},
-										},
-									],
-								],
+											],
+									  ]
+									: [
+											[
+												require.resolve('babel-plugin-named-asset-import'),
+												{
+													loaderMap: {
+														svg: {
+															ReactComponent:
+																'@svgr/webpack?-svgo,+titleProp,+ref![path]',
+														},
+													},
+												},
+											],
+											require.resolve('babel-plugin-istanbul'),
+									  ],
 								// This is a feature of `babel-loader` for webpack (not Babel itself).
 								// It enables caching results in ./node_modules/.cache/babel-loader/
 								// directory for faster rebuilds.

--- a/cypress/e2e/common/MetaTags.js
+++ b/cypress/e2e/common/MetaTags.js
@@ -2,7 +2,7 @@
 import { Then } from 'cypress-cucumber-preprocessor/steps';
 
 Then('the page contains meta tags with the following names', (dataTable) => {
-	cy.document().then((doc) => {
+	cy.document().then(() => {
 		for (const { name, content } of dataTable.hashes()) {
 			const locator = `meta[name='${name}']`;
 			//find element, ensure it has attribute content

--- a/cypress/e2e/common/analytics.js
+++ b/cypress/e2e/common/analytics.js
@@ -1,5 +1,5 @@
 /// <reference types="Cypress" />
-import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 /**
  * Converts a string value to a native data type if indicated in the map.
@@ -8,11 +8,11 @@ import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 const convertValue = (val) => {
 	if (typeof val === 'string') {
 		if (val.indexOf('(int)') === 0) {
-			return parseInt(val.replace('(int)', ''))
+			return parseInt(val.replace('(int)', ''));
 		}
 	}
 	return val;
-}
+};
 
 /**
  * Converts an object with a.b.c styled keys into an
@@ -20,71 +20,61 @@ const convertValue = (val) => {
  * @param {object} obj The DataTable.hashes()
  */
 const convertAnalyticsDatatableObject = (obj) => {
-  const objPass1 = Object.keys(obj)
-    .map(key => {
+	const objPass1 = Object.keys(obj)
+		.map((key) => {
 			const [first, ...rest] = key.split('.');
-      if (rest.length > 0) {
+			if (rest.length > 0) {
 				const newRestKey = rest.join('.');
 				const value = convertValue(obj[first + '.' + newRestKey]);
-        return {
-          first,
-          rest: {
-            [newRestKey]: value
-          }
-        }
-      } else {
-        return {
-          first,
-          value: obj[first]
-        }
-      }
-    })
-    .reduce(
-      (ac,curr) => {
-        const newKey = curr.first;
+				return {
+					first,
+					rest: {
+						[newRestKey]: value,
+					},
+				};
+			} else {
+				return {
+					first,
+					value: obj[first],
+				};
+			}
+		})
+		.reduce((ac, curr) => {
+			const newKey = curr.first;
 
-				if (curr.value !== undefined) {
-          if (ac[newKey]) {
-            throw new Error(`Key, ${newKey}, is already defined.`);
-          }
-          return {
-            [newKey]: curr.value,
-            ...ac
-          }
-        } else if (curr.rest) {
-          if (ac[newKey] && typeof ac[newKey] !== 'object') {
-            throw new Error(`Key, ${newKey}, is mixing values and objects.`);
-          }
+			if (curr.value !== undefined) {
+				if (ac[newKey]) {
+					throw new Error(`Key, ${newKey}, is already defined.`);
+				}
+				return {
+					[newKey]: curr.value,
+					...ac,
+				};
+			} else if (curr.rest) {
+				if (ac[newKey] && typeof ac[newKey] !== 'object') {
+					throw new Error(`Key, ${newKey}, is mixing values and objects.`);
+				}
 
-          return {
-            ...ac,
-            [newKey]: {
-              ...ac[newKey],
-              ...curr.rest
-            }
-          }
-
-        } else {
-          // This is not good
-          return ac;
-        }
-      },
-      {}
-    );
-  return Object.entries(objPass1)
-    .reduce(
-      (ac, [key, val] = {}) => {
-        return {
-          ...ac,
-          [key]: (typeof val === "object") ?
-					convertAnalyticsDatatableObject(val) :
-            val
-        }
-      },
-      {}
-    );
-
-}
+				return {
+					...ac,
+					[newKey]: {
+						...ac[newKey],
+						...curr.rest,
+					},
+				};
+			} else {
+				// This is not good
+				return ac;
+			}
+		}, {});
+	return Object.entries(objPass1).reduce((ac, [key, val] = {}) => {
+		return {
+			...ac,
+			[key]:
+				typeof val === 'object' ? convertAnalyticsDatatableObject(val) : val,
+		};
+	}, {});
+};
 
 /**
  * Finds an event with the following information.
@@ -92,7 +82,9 @@ const convertAnalyticsDatatableObject = (obj) => {
  * @param {string} event The name of the event
  */
 const getEventFromEDDL = (win, type, event) => {
-	return win.NCIDataLayer.filter(evt => evt.type === type && evt.event === event);
+	return win.NCIDataLayer.filter(
+		(evt) => evt.type === type && evt.event === event
+	);
 };
 
 When('the NCIDataLayer is cleared', () => {
@@ -122,24 +114,24 @@ Then(
 				}
 				return {
 					...ac,
-					[key]: val
-				}
-			}, {})
+					[key]: val,
+				};
+			}, {});
 
 			if (!dataObj.event) {
-				throw new Error("Datatable is missing the event name")
+				throw new Error('Datatable is missing the event name');
 			}
 
 			if (!dataObj.type) {
-				throw new Error("Datatable is missing the event type")
+				throw new Error('Datatable is missing the event type');
 			}
 
 			// Find the matching events, this should be only one.
 			const matchedEvents = getEventFromEDDL(win, dataObj.type, dataObj.event);
 			expect(matchedEvents).to.have.length(1);
 
-      const eventData = matchedEvents[0];
-      console.log(eventData)
+			const eventData = matchedEvents[0];
+			console.log(eventData);
 
 			// This is a cheat. For the most part we know all the values so this
 			// is ok. We won't support regex matching this way.

--- a/cypress/e2e/common/beforeEach.js
+++ b/cypress/e2e/common/beforeEach.js
@@ -23,8 +23,8 @@ beforeEach(() => {
 			searchSiteFilter: 'all',
 			siteName: 'National Cancer Institute',
 			title: 'NCI Search Results',
-			contentGroup: "Global Search",
-			audience: "Patient"
+			contentGroup: 'Global Search',
+			audience: 'Patient',
 		};
 		console.log(win.INT_TEST_APP_PARAMS);
 	});

--- a/cypress/e2e/common/index.js
+++ b/cypress/e2e/common/index.js
@@ -1,8 +1,6 @@
 import { And, Given, Then } from 'cypress-cucumber-preprocessor/steps';
 import { i18n } from '../../../src/utils';
 
-const baseURL = Cypress.config('baseUrl');
-
 Then('page title is {string}', (title) => {
 	cy.get('h1').should('contain', title);
 });
@@ -12,7 +10,7 @@ Then('the page title is {string}', (title) => {
 });
 
 Then('page title on error page is {string}', (title) => {
-	Cypress.on('uncaught:exception', (err, runnable) => {
+	Cypress.on('uncaught:exception', () => {
 		// returning false here to Cypress from
 		// failing the test
 		return false;
@@ -29,7 +27,7 @@ Given('the user visits the home page', () => {
 	cy.visit('/');
 });
 
-Given('the user navigates to {string}',  (destURL) => {
+Given('the user navigates to {string}', (destURL) => {
 	cy.visit(destURL);
 });
 
@@ -49,7 +47,7 @@ Given('{string} is set to {string}', (key, param) => {
     ----------------------------------------
 */
 Then('the user gets an error page that reads {string}', (errorMessage) => {
-	Cypress.on('uncaught:exception', (err, runnable) => {
+	Cypress.on('uncaught:exception', () => {
 		// returning false here to Cypress from
 		// failing the test
 		return false;
@@ -93,10 +91,10 @@ And('the following links and texts exist on the page', (dataTable) => {
     -----------------------
 */
 And('the system returns the no results found page', () => {
-
 	cy.window().then((win) => {
 		if (win.INT_TEST_APP_PARAMS) {
-			const noResultsPageTitle =  i18n.nciSearchResults[win.INT_TEST_APP_PARAMS.language];
+			const noResultsPageTitle =
+				i18n.nciSearchResults[win.INT_TEST_APP_PARAMS.language];
 			cy.get('h1').should('contain', noResultsPageTitle);
 		}
 	});

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -4,14 +4,8 @@
  * This file is the configuration for the final merged report.
  */
 module.exports = {
-	'report-dir': 'coverage/merged',
-	'temp-dir': 'coverage/merged',
-	reporter: ['html', 'json', 'lcov', 'text'],
-	'check-coverage': true,
-	branches: 75, // Target of 80 across all repos.
-	lines: 80,
-	functions: 80,
-	statements: 80,
+	'report-dir': 'coverage/cypress',
+	reporter: ['html', 'json', 'lcov'],
 	exclude: [
 		'cypress/**/*.js',
 		'jest-test-setup.js',

--- a/package.json
+++ b/package.json
@@ -45,24 +45,29 @@
 	},
 	"scripts": {
 		"start": "node scripts/start.js",
+		"start:silent": "BROWSER=none npm start",
 		"build:cgdp-legacy": "node scripts/generate-cgdp-legacy.js",
 		"build:cra": "node scripts/build.js",
 		"build": "npm run build:cra && npm run build:cgdp-legacy",
-		"test": "NODE_ENV=test npm run lint && NODE_ENV=test npm run pa11y-tests && NODE_ENV=test npm run unit-tests && NODE_ENV=test npm run cy:ci && npm run merge-coverage",
-		"test:it": "cypress open",
+		"test": "npm run unit-tests && npm run cy:ci && npm run merge-coverage",
+		"test:it": "NODE_ENV=test cypress open",
 		"test:pa11y": "./node_modules/.bin/pa11y-ci",
 		"pa11y-tests": "start-server-and-test start http://localhost:3000 pa11y",
 		"pa11y": "pa11y-ci",
-		"cy:ci": "start-server-and-test start http://localhost:3000 integration-tests && nyc report -t coverage/cypress --reporter text --report-dir coverage/merged",
+		"cy:ci": "start-server-and-test start:silent http://localhost:3000 integration-tests",
 		"unit-tests": "jest",
-		"integration-tests": "cypress run",
+		"integration-tests": "NODE_ENV=test cypress run && nyc report -t coverage/cypress --reporter text --report-dir coverage/cypress",
 		"merge-coverage": "npm run mc:pre && npm run mc:merge && npm run mc:report",
 		"mc:pre": "node scripts/pre-merge-coverage",
 		"mc:merge": "nyc merge coverage/tmp coverage/merged/coverage-final.json",
 		"mc:report": "nyc report --nycrc-path=merged.nyc.config.js",
 		"format": "prettier --write \"**/*.+(js|jsx|json|css|md)\"",
-		"lint": "eslint src --ext .js,.jsx",
-		"lint:fix": "eslint src --ext .js,.jsx --fix"
+		"lint": "npm run lint:src && npm run lint:cypress",
+		"lint:src": "eslint src --ext .js,.jsx",
+		"lint:cypress": "eslint cypress/e2e --ext .js,.jsx",
+		"lint:fix": "npm run lint:src:fix && npm run lint:cypress:fix",
+		"lint:src:fix": "eslint src --ext .js,.jsx --fix",
+		"lint:cypress:fix": "eslint cypress/e2e --ext .js,.jsx --fix"
 	},
 	"browserslist": {
 		"production": [
@@ -85,15 +90,16 @@
 		"collectCoverage": true,
 		"coverageDirectory": "coverage/jest",
 		"collectCoverageFrom": [
-			"src/**/*.test.{js,jsx,ts,tsx}",
+			"src/**/*.{js,jsx,ts,tsx}",
+			"!src/**/*.test.{js,jsx,ts,tsx}",
 			"!src/**/*.d.ts",
 			"!cypress/**/*.{spec,test}.{js,jsx,ts,tsx}"
 		],
 		"coverageThreshold": {
 			"global": {
-				"branches": 80,
-				"functions": 80,
-				"lines": 80
+				"branches": 63,
+				"functions": 72,
+				"lines": 78
 			}
 		},
 		"setupFiles": [
@@ -143,19 +149,6 @@
 		"nonGlobalStepDefinitions": true,
 		"stepDefinitions": "cypress/e2e",
 		"commonPath": "cypress/e2e/common"
-	},
-	"nyc": {
-		"report-dir": "coverage/cypress",
-		"reporter": [
-			"html",
-			"json",
-			"lcov"
-		],
-		"exclude": [
-			"cypress/**/*.js",
-			"jest-test-setup.js",
-			"src/setupTests.js"
-		]
 	},
 	"devDependencies": {
 		"@babel/core": "7.9.0",


### PR DESCRIPTION
Note: Reference #90 for steps to follow in other repos.

* Fixes coverage collection (Note: This results in a decrease in our coverage score)
    *  Updates coverage collection key to specify the src directory and exclude test files:
```		
    "collectCoverageFrom": [
			      "src/**/*.{js,jsx,ts,tsx}",
			      "!src/**/*.test.{js,jsx,ts,tsx}",
			      "!src/**/*.d.ts",
			      "!cypress/**/*.{spec,test}.{js,jsx,ts,tsx}"
		      ],
 ```

* Modifies coverage threshold to current / as-is coverage
      (Note: The ideal minimum target for all repositories should be 80%. As we will most likely be refactoring chunks of the codebase we agreed to codify current thresholds and target between current scores and 80(+) for newly introduced code ) 

 * Updates webpack config file to add istanbul plugin on non-Prod environments
    * Removes plugin add from babel config

* Moves the nyc config from package.json to nyc.config.json for visibility / consistency
* Excludes Create React App scaffolding files from code coverage collection
*  Includes Cypress JS files in code standards checks

Closes #90