### PR TITLE
(#93) (#78) Set-output and pass in paths

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -56,11 +56,11 @@ jobs:
           REPO_NAME=$(echo "${BASH_REMATCH[2]}")
 
           ## Set step outputs for later use
-          echo ::set-output name=build_name::${BUILD_NAME}
-          echo ::set-output name=branch_name::${BRANCH_NAME}
-          echo ::set-output name=commit_hash::${COMMIT_HASH}
-          echo ::set-output name=repo_owner::${REPO_OWNER}
-          echo ::set-output name=repo_name::${REPO_NAME}
+          echo "build_name=${BUILD_NAME}" >> $GITHUB_OUTPUT
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "commit_hash=${COMMIT_HASH}" >> $GITHUB_OUTPUT
+          echo "repo_owner=${REPO_OWNER}" >> $GITHUB_OUTPUT
+          echo "repo_name=${REPO_NAME}" >> $GITHUB_OUTPUT
       - name: Add Comment on Where to Test
         uses: actions/github-script@v6
         if: startsWith(github.repository, 'NCIOCPL') && github.event_name == 'pull_request' && github.event.action == 'opened'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,14 +13,24 @@ on:
       - '*'
   pull_request:
   workflow_call:
+    inputs:
+      app_path:
+        description: Is there a path prefix for the app
+        required: false
+        type: string
+        default: "./"
 jobs:
   build:
     name: Build, Test and Upload Artifacts
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ${{ format('./{0}', inputs.app_path) }}
     steps:
       ## Setup variables for build info
       - name: Set Variables
         id: set_vars
+        working-directory: "./"
         run: |
           ## PUSH
           if [ "${{ github.event_name }}" == "push" ]; then
@@ -77,10 +87,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: '${{ inputs.app_path }}.nvmrc'
           cache: 'npm'
           registry-url: https://npm.pkg.github.com
           scope: '@nciocpl'
+          cache-dependency-path: '**/package-lock.json'
       ## Install using CI
       - name: Install Dependencies
         run: npm ci
@@ -119,13 +130,13 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: test-results
-          path: coverage
+          path: ${{ inputs.app_path }}coverage
       ## Upload the test results artifact
       - name: Archive production artifacts
         uses: actions/upload-artifact@v1
         with:
           name: build-artifact
-          path: build
+          path: ${{ inputs.app_path }}build
   deploy-test:
     name: Deploy built artifacts to test server
     ## Only do this if the repo is NCIOCPL


### PR DESCRIPTION
Backport changes from `workflow/v2` into `develop` because I got the process wrong.